### PR TITLE
fix: resolve duplicate Vue key warnings in passkeys and access keys tables

### DIFF
--- a/app/src/components/AccountAccessKeys.vue
+++ b/app/src/components/AccountAccessKeys.vue
@@ -21,7 +21,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr v-for="cred in list" :key="rowKey" class="desktop">
+                    <tr v-for="cred in list" :key="`desktop-${cred.id}`" class="desktop">
                         <td>
                             {{ new Date(cred.created_at).toDateString() }}
                         </td>
@@ -38,7 +38,7 @@
                             </button>
                         </td>
                     </tr>
-                    <tr v-for="cred in list" :key="rowKey" class="tablet">
+                    <tr v-for="cred in list" :key="`tablet-${cred.id}`" class="tablet">
                         <hr>
                         <div class="flex gap-2 justify-between">
                             <div class="text-start">
@@ -77,14 +77,12 @@ const credential = {
 
 const list = ref([] as typeof credential[])
 const error = ref('')
-const rowKey = ref(0)
 
 const getList = async () => {
     try {
         const res = await userApi.accessKeyList()
         list.value = res.data
         error.value = ''
-        renderRow()
     } catch (err) {
         if (axios.isAxiosError(err)) {
             error.value = err.message
@@ -99,16 +97,11 @@ const deleteAccessKey = async (id: string) => {
         await userApi.accessKeyDelete(id)
         list.value = list.value.filter((cred: any) => cred.id !== id)
         error.value = ''
-        renderRow()
     } catch (err) {
         if (axios.isAxiosError(err)) {
             error.value = err.message
         }
     }
-}
-
-const renderRow = () => {
-    rowKey.value++
 }
 
 onMounted(() => {

--- a/app/src/components/AccountPasskeys.vue
+++ b/app/src/components/AccountPasskeys.vue
@@ -27,7 +27,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr v-for="cred in list" :key="rowKey" class="desktop">
+                    <tr v-for="cred in list" :key="`desktop-${cred.id}`" class="desktop">
                         <td>
                             {{ new Date(cred.created_at).toDateString() }}
                         </td>
@@ -41,7 +41,7 @@
                             </button>
                         </td>
                     </tr>
-                    <tr v-for="cred in list" :key="rowKey" class="tablet">
+                    <tr v-for="cred in list" :key="`tablet-${cred.id}`" class="tablet">
                         <hr>
                         <div class="flex gap-2 justify-between">
                             <div class="text-start">
@@ -78,14 +78,12 @@ const credential = {
 const list = ref([] as typeof credential[])
 const error = ref('')
 const passkeySupported = ref(false)
-const rowKey = ref(0)
 
 const getList = async () => {
     try {
         const res = await userApi.getCredentials()
         list.value = res.data
         error.value = ''
-        renderRow()
     } catch (err) {
         if (axios.isAxiosError(err)) {
             error.value = err.message
@@ -100,7 +98,6 @@ const deleteCred = async (id: string) => {
         await userApi.deleteCredential(id)
         list.value = list.value.filter((cred: any) => cred.id !== id)
         error.value = ''
-        renderRow()
     } catch (err) {
         if (axios.isAxiosError(err)) {
             error.value = err.message
@@ -140,10 +137,6 @@ const startAddPasskey = async (res: any) => {
             error.value = 'The operation was aborted or failed.'
         }
     }
-}
-
-const renderRow = () => {
-    rowKey.value++
 }
 
 onMounted(() => {


### PR DESCRIPTION
fix: resolve duplicate Vue key warnings in passkeys and access keys tables

  - Use unique credential ID as key instead of shared rowKey counter
  - Add prefix to distinguish desktop and tablet row variants
  - Remove unused rowKey ref and renderRow() function

  Fixes Vue console warnings about duplicate :key values in v-for loops.
  Previously both desktop and tablet rows used the same rowKey counter,
  causing rendering issues and Vue warnings.

  Now each row has a unique key: desktop-{id} and tablet-{id}.

## PR type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Other information
### Summary
  Fixes duplicate Vue `:key` warnings in Passkeys and Access Keys tables by using unique credential IDs instead of a shared counter.

 ### Problem
  Both `AccountPasskeys.vue` and `AccountAccessKeys.vue` had duplicate key issues:

  **Before:**
  ```vue
  <tr v-for="cred in list" :key="rowKey" class="desktop">
  <!-- desktop row -->
  </tr>
  <tr v-for="cred in list" :key="rowKey" class="tablet">
  <!-- tablet row -->
  </tr>
```

  Both loops used :key="rowKey" - the same counter! This caused:
  - ❌ Vue console warnings: "Duplicate keys detected"
  - ❌ Rendering glitches when adding/deleting items
  - ❌ Poor Vue performance due to key conflicts

  Solution

  Use unique credential IDs with prefixes to distinguish desktop/tablet variants:

  After:
 ```vue
  <tr v-for="cred in list" :key="`desktop-${cred.id}`" class="desktop">
  <!-- desktop row -->
  </tr>
  <tr v-for="cred in list" :key="`tablet-${cred.id}`" class="tablet">
  <!-- tablet row -->
  </tr>
 ```

  Changes

  - app/src/components/AccountPasskeys.vue:
    - Changed :key="rowKey" to :key="desktop-${cred.id}"
    - Changed :key="rowKey" to :key="tablet-${cred.id}"
    - Removed unused rowKey ref
    - Removed unused renderRow() function
    - Removed renderRow() calls
  - app/src/components/AccountAccessKeys.vue:
    - Same fixes as above
